### PR TITLE
Create new structs for condensed data storage format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,10 @@ yew = "0.16"
 # allocator, however.
 wee_alloc = { version = "0.4.2", optional = true }
 
+[dependencies.chrono]
+version = "0.4"
+features = ["serde", "wasmbind"]
+
 [dev-dependencies]
 js-sys = "0.3.37"
 wasm-bindgen-futures = "0.4.10"

--- a/src/app.rs
+++ b/src/app.rs
@@ -81,7 +81,7 @@ impl Component for App {
 
     fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
         let storage = StorageService::new().unwrap();
-        let entries = storage.restore_or_default();
+        let entries = storage.restore();
 
         let state = State {
             entries,

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -1,3 +1,4 @@
+use super::storage::CompletedItem;
 use super::Entry;
 use serde_derive::{Deserialize, Serialize};
 use std::fmt::Display;
@@ -694,48 +695,142 @@ impl<T: EntryCompatible> From<T> for Entry {
     }
 }
 
-pub fn amulet_entries() -> Vec<Entry> {
-    Amulet::entries()
+pub fn amulet_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = Amulet::entries();
+    for entry in &mut entries {
+        if defaults
+            .iter()
+            .any(|default| default.id == entry.id && matches!(default.data_type, DataType::Amulet))
+        {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn armor_set_entries() -> Vec<Entry> {
-    ArmorSet::entries()
+pub fn armor_set_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = ArmorSet::entries();
+    for entry in &mut entries {
+        if defaults.iter().any(|default| {
+            default.id == entry.id && matches!(default.data_type, DataType::ArmorSet)
+        }) {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn body_armor_entries() -> Vec<Entry> {
-    BodyArmor::entries()
+pub fn body_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = BodyArmor::entries();
+    for entry in &mut entries {
+        if defaults.iter().any(|default| {
+            default.id == entry.id && matches!(default.data_type, DataType::BodyArmor)
+        }) {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn emote_entries() -> Vec<Entry> {
-    Emote::entries()
+pub fn emote_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = Emote::entries();
+    for entry in &mut entries {
+        if defaults
+            .iter()
+            .any(|default| default.id == entry.id && matches!(default.data_type, DataType::Emote))
+        {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn hand_gun_entries() -> Vec<Entry> {
-    HandGun::entries()
+pub fn hand_gun_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = HandGun::entries();
+    for entry in &mut entries {
+        if defaults
+            .iter()
+            .any(|default| default.id == entry.id && matches!(default.data_type, DataType::HandGun))
+        {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn head_armor_entries() -> Vec<Entry> {
-    HeadArmor::entries()
+pub fn head_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = HeadArmor::entries();
+    for entry in &mut entries {
+        if defaults.iter().any(|default| {
+            default.id == entry.id && matches!(default.data_type, DataType::HeadArmor)
+        }) {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn leg_armor_entries() -> Vec<Entry> {
-    LegArmor::entries()
+pub fn leg_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = LegArmor::entries();
+    for entry in &mut entries {
+        if defaults.iter().any(|default| {
+            default.id == entry.id && matches!(default.data_type, DataType::LegArmor)
+        }) {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn long_gun_entries() -> Vec<Entry> {
-    LongGun::entries()
+pub fn long_gun_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = LongGun::entries();
+    for entry in &mut entries {
+        if defaults
+            .iter()
+            .any(|default| default.id == entry.id && matches!(default.data_type, DataType::LongGun))
+        {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn melee_weapon_entries() -> Vec<Entry> {
-    MeleeWeapon::entries()
+pub fn melee_weapon_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = MeleeWeapon::entries();
+    for entry in &mut entries {
+        if defaults.iter().any(|default| {
+            default.id == entry.id && matches!(default.data_type, DataType::MeleeWeapon)
+        }) {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn remnant_trait_entries() -> Vec<Entry> {
-    Trait::entries()
+pub fn remnant_trait_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = Trait::entries();
+    for entry in &mut entries {
+        if defaults
+            .iter()
+            .any(|default| default.id == entry.id && matches!(default.data_type, DataType::Trait))
+        {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
-pub fn ring_entries() -> Vec<Entry> {
-    Ring::entries()
+pub fn ring_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
+    let mut entries = Ring::entries();
+    for entry in &mut entries {
+        if defaults
+            .iter()
+            .any(|default| default.id == entry.id && matches!(default.data_type, DataType::Ring))
+        {
+            entry.completed = true;
+        }
+    }
+    entries
 }
 
 #[cfg(test)]

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -32,7 +32,7 @@ impl Display for World {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Copy, Clone, Serialize, Deserialize)]
 pub enum DataType {
     Amulet,
     ArmorSet,

--- a/src/app/data.rs
+++ b/src/app/data.rs
@@ -697,6 +697,8 @@ impl<T: EntryCompatible> From<T> for Entry {
 
 pub fn amulet_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = Amulet::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults
             .iter()
@@ -710,6 +712,8 @@ pub fn amulet_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn armor_set_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = ArmorSet::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults.iter().any(|default| {
             default.id == entry.id && matches!(default.data_type, DataType::ArmorSet)
@@ -722,6 +726,8 @@ pub fn armor_set_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn body_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = BodyArmor::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults.iter().any(|default| {
             default.id == entry.id && matches!(default.data_type, DataType::BodyArmor)
@@ -734,6 +740,8 @@ pub fn body_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn emote_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = Emote::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults
             .iter()
@@ -747,6 +755,8 @@ pub fn emote_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn hand_gun_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = HandGun::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults
             .iter()
@@ -760,6 +770,8 @@ pub fn hand_gun_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn head_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = HeadArmor::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults.iter().any(|default| {
             default.id == entry.id && matches!(default.data_type, DataType::HeadArmor)
@@ -772,6 +784,8 @@ pub fn head_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn leg_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = LegArmor::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults.iter().any(|default| {
             default.id == entry.id && matches!(default.data_type, DataType::LegArmor)
@@ -784,6 +798,8 @@ pub fn leg_armor_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn long_gun_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = LongGun::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults
             .iter()
@@ -797,6 +813,8 @@ pub fn long_gun_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn melee_weapon_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = MeleeWeapon::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults.iter().any(|default| {
             default.id == entry.id && matches!(default.data_type, DataType::MeleeWeapon)
@@ -809,6 +827,8 @@ pub fn melee_weapon_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn remnant_trait_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = Trait::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults
             .iter()
@@ -822,6 +842,8 @@ pub fn remnant_trait_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
 
 pub fn ring_entries(defaults: &[CompletedItem]) -> Vec<Entry> {
     let mut entries = Ring::entries();
+
+    #[allow(clippy::block_in_if_condition_stmt)]
     for entry in &mut entries {
         if defaults
             .iter()

--- a/src/app/storage.rs
+++ b/src/app/storage.rs
@@ -1,9 +1,13 @@
+mod data_format;
+
 use super::data;
 use super::Entry;
+use data_format::DataFormat;
 use yew::format::Json;
 use yew::services::storage::{Area, StorageService as YewStorageService};
 
 const KEY: &str = "dev.coffee.remnant";
+const KEY_CONDENSED: &str = "dev.coffee.remnant.condensed";
 
 pub struct StorageService {
     storage_service: YewStorageService,
@@ -37,6 +41,8 @@ impl StorageService {
 
     #[allow(clippy::ptr_arg)]
     pub fn store(&mut self, value: &Vec<Entry>) {
-        self.storage_service.store(KEY, Json(value))
+        self.storage_service.store(KEY, Json(value));
+        self.storage_service
+            .store(KEY_CONDENSED, Json(&DataFormat::new(value)));
     }
 }

--- a/src/app/storage/data_format.rs
+++ b/src/app/storage/data_format.rs
@@ -7,7 +7,7 @@ const DATA_FORMAT_VERSION: usize = 1;
 
 #[derive(Deserialize, Serialize)]
 pub struct DataFormat {
-    completed_items: Vec<Item>,
+    pub completed_items: Vec<Item>,
     last_saved_at: DateTime<Utc>,
     version: usize,
 }
@@ -50,9 +50,9 @@ impl Default for DataFormat {
 }
 
 #[derive(Deserialize, Serialize)]
-struct Item {
-    data_type: DataType,
-    id: u32,
+pub struct Item {
+    pub data_type: DataType,
+    pub id: u32,
 }
 
 #[cfg(test)]

--- a/src/app/storage/data_format.rs
+++ b/src/app/storage/data_format.rs
@@ -1,0 +1,110 @@
+use super::data::DataType;
+use super::Entry;
+use serde_derive::{Deserialize, Serialize};
+
+const DATA_FORMAT_VERSION: usize = 1;
+
+#[derive(Deserialize, Serialize)]
+pub struct DataFormat {
+    completed_items: Vec<Item>,
+    version: usize,
+}
+
+impl DataFormat {
+    pub fn new(entries: &[Entry]) -> Self {
+        DataFormat {
+            completed_items: entries
+                .iter()
+                .filter_map(|entry| {
+                    if entry.completed {
+                        Some(Item::from(entry))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+}
+
+impl From<&Entry> for Item {
+    fn from(entry: &Entry) -> Self {
+        Item {
+            data_type: entry.data_type,
+            id: entry.id,
+        }
+    }
+}
+
+impl Default for DataFormat {
+    fn default() -> Self {
+        DataFormat {
+            completed_items: Default::default(),
+            version: DATA_FORMAT_VERSION,
+        }
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+struct Item {
+    data_type: DataType,
+    id: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_data_format_defaults() {
+        let data: DataFormat = Default::default();
+
+        assert!(data.completed_items.is_empty());
+        assert_eq!(DATA_FORMAT_VERSION, data.version);
+    }
+
+    #[test]
+    fn test_data_format_version_can_differ() {
+        let data = DataFormat {
+            version: 42,
+            ..Default::default()
+        };
+
+        assert_eq!(42, data.version);
+    }
+
+    mod new {
+        use super::*;
+
+        fn build_entry(completed: bool, data_type: DataType, id: u32) -> Entry {
+            Entry {
+                completed,
+                data_type,
+                icon: 'x',
+                id,
+                name: "Necklace".into(),
+                url: "https://example.com".into(),
+            }
+        }
+
+        #[test]
+        fn test_new_converts_completd_entries_into_items() {
+            let entries = vec![
+                build_entry(true, DataType::Amulet, 4),
+                build_entry(false, DataType::LegArmor, 5),
+                build_entry(true, DataType::Ring, 6),
+                build_entry(false, DataType::HeadArmor, 7),
+            ];
+            let completed_items = DataFormat::new(&entries).completed_items;
+
+            let item = completed_items.first().unwrap();
+            assert!(matches!(item.data_type, DataType::Amulet));
+            assert_eq!(4, item.id);
+
+            let item = completed_items.last().unwrap();
+            assert!(matches!(item.data_type, DataType::Ring));
+            assert_eq!(6, item.id);
+        }
+    }
+}

--- a/src/app/storage/data_format.rs
+++ b/src/app/storage/data_format.rs
@@ -1,5 +1,5 @@
-use super::data::DataType;
-use super::Entry;
+use crate::app::data::DataType;
+use crate::app::Entry;
 use chrono::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 

--- a/src/app/storage/data_format.rs
+++ b/src/app/storage/data_format.rs
@@ -1,5 +1,6 @@
 use super::data::DataType;
 use super::Entry;
+use chrono::{DateTime, Utc};
 use serde_derive::{Deserialize, Serialize};
 
 const DATA_FORMAT_VERSION: usize = 1;
@@ -7,6 +8,7 @@ const DATA_FORMAT_VERSION: usize = 1;
 #[derive(Deserialize, Serialize)]
 pub struct DataFormat {
     completed_items: Vec<Item>,
+    last_saved_at: DateTime<Utc>,
     version: usize,
 }
 
@@ -41,6 +43,7 @@ impl Default for DataFormat {
     fn default() -> Self {
         DataFormat {
             completed_items: Default::default(),
+            last_saved_at: Utc::now(),
             version: DATA_FORMAT_VERSION,
         }
     }
@@ -55,13 +58,16 @@ struct Item {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration;
 
     #[test]
     fn test_data_format_defaults() {
+        let now = Utc::now().checked_add_signed(Duration::seconds(1)).unwrap();
         let data: DataFormat = Default::default();
 
         assert!(data.completed_items.is_empty());
         assert_eq!(DATA_FORMAT_VERSION, data.version);
+        assert!(now > data.last_saved_at);
     }
 
     #[test]

--- a/src/app/storage/mod.rs
+++ b/src/app/storage/mod.rs
@@ -1,0 +1,4 @@
+mod data_format;
+mod storage_service;
+
+pub use storage_service::StorageService;

--- a/src/app/storage/mod.rs
+++ b/src/app/storage/mod.rs
@@ -1,4 +1,5 @@
 mod data_format;
 mod storage_service;
 
+pub use data_format::Item as CompletedItem;
 pub use storage_service::StorageService;

--- a/src/app/storage/storage_service.rs
+++ b/src/app/storage/storage_service.rs
@@ -5,7 +5,6 @@ use yew::format::Json;
 use yew::services::storage::{Area, StorageService as YewStorageService};
 
 const KEY: &str = "dev.coffee.remnant";
-const KEY_CONDENSED: &str = "dev.coffee.remnant.condensed";
 
 pub struct StorageService {
     storage_service: YewStorageService,
@@ -18,29 +17,36 @@ impl StorageService {
             .map_err(|error| error)
     }
 
-    pub fn restore_or_default(&self) -> Vec<Entry> {
-        if let Json(Ok(restored_entries)) = self.storage_service.restore(KEY) {
-            restored_entries
-        } else {
-            let mut entries = data::remnant_trait_entries();
-            entries.append(&mut data::amulet_entries());
-            entries.append(&mut data::armor_set_entries());
-            entries.append(&mut data::head_armor_entries());
-            entries.append(&mut data::body_armor_entries());
-            entries.append(&mut data::leg_armor_entries());
-            entries.append(&mut data::emote_entries());
-            entries.append(&mut data::ring_entries());
-            entries.append(&mut data::hand_gun_entries());
-            entries.append(&mut data::long_gun_entries());
-            entries.append(&mut data::melee_weapon_entries());
-            entries
-        }
+    pub fn restore(&self) -> Vec<Entry> {
+        let data = self.retrieve_stored_data();
+
+        let mut entries = data::remnant_trait_entries(&data.completed_items);
+        entries.append(&mut data::amulet_entries(&data.completed_items));
+        entries.append(&mut data::armor_set_entries(&data.completed_items));
+        entries.append(&mut data::head_armor_entries(&data.completed_items));
+        entries.append(&mut data::body_armor_entries(&data.completed_items));
+        entries.append(&mut data::leg_armor_entries(&data.completed_items));
+        entries.append(&mut data::emote_entries(&data.completed_items));
+        entries.append(&mut data::ring_entries(&data.completed_items));
+        entries.append(&mut data::hand_gun_entries(&data.completed_items));
+        entries.append(&mut data::long_gun_entries(&data.completed_items));
+        entries.append(&mut data::melee_weapon_entries(&data.completed_items));
+        entries
     }
 
     #[allow(clippy::ptr_arg)]
     pub fn store(&mut self, value: &Vec<Entry>) {
-        self.storage_service.store(KEY, Json(value));
         self.storage_service
-            .store(KEY_CONDENSED, Json(&DataFormat::new(value)));
+            .store(KEY, Json(&DataFormat::new(value)));
+    }
+}
+
+impl StorageService {
+    fn retrieve_stored_data(&self) -> DataFormat {
+        if let Json(Ok(restored_data)) = self.storage_service.restore(KEY) {
+            restored_data
+        } else {
+            DataFormat::default()
+        }
     }
 }

--- a/src/app/storage/storage_service.rs
+++ b/src/app/storage/storage_service.rs
@@ -1,8 +1,6 @@
-mod data_format;
-
-use super::data;
-use super::Entry;
-use data_format::DataFormat;
+use super::data_format::DataFormat;
+use crate::app::data;
+use crate::app::Entry;
 use yew::format::Json;
 use yew::services::storage::{Area, StorageService as YewStorageService};
 


### PR DESCRIPTION
Instead of storing more properties than we need as well as more data than we need, we can store a smaller subset of data and use methods that deflate and inflate it as needed.

This is only part of the solution so far and does not inflate yet.

This starts #11 and will allow easier completion of #9